### PR TITLE
Member 엔티티와 관련된 로직 수정 및 로그인에 Spring Security 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/spring/board/BoardApplication.java
+++ b/src/main/java/spring/board/BoardApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class BoardApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/spring/board/common/config/JpaConfig.java
+++ b/src/main/java/spring/board/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package spring.board.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/spring/board/common/config/SecurityConfig.java
+++ b/src/main/java/spring/board/common/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package spring.board.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import spring.board.service.LoginService;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final LoginService loginService;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    @Bean
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(loginService).passwordEncoder(passwordEncoder());
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web
+                .ignoring()
+                .antMatchers("/css/**", "/js/**");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeRequests()
+                    .antMatchers("/", "/login", "/members/new")
+                    .permitAll()
+                .anyRequest()
+                    .authenticated()
+                .and()
+                .formLogin()
+                    .loginPage("/login")
+                    .loginProcessingUrl("/login")
+                    .usernameParameter("loginId")
+                    .passwordParameter("password")
+                .and()
+                .logout()
+                .logoutSuccessUrl("/")
+                .invalidateHttpSession(true);
+    }
+}

--- a/src/main/java/spring/board/controller/LoginController.java
+++ b/src/main/java/spring/board/controller/LoginController.java
@@ -19,36 +19,8 @@ import javax.validation.Valid;
 @Controller
 public class LoginController {
 
-    private final LoginService loginService;
-
-    @ExceptionHandler(CredentialException.class)
-    private String handleCredentialException(CredentialException ex, Model model) {
-        model.addAttribute("loginForm", new LoginForm());
-        model.addAttribute("message", "가입되지 않은 사용자이거나 잘못된 비밀번호 입니다.");
-        return "loginForm";
-    }
-
     @GetMapping("/login")
     public String createLoginForm(@ModelAttribute("loginForm")LoginForm loginForm) {
         return "loginForm";
-    }
-
-    @PostMapping("/login")
-    public String login(@Valid @ModelAttribute LoginForm loginForm, BindingResult bindingResult,
-                        @RequestParam(defaultValue = "/") String redirectURL, HttpServletRequest request) {
-        if (bindingResult.hasErrors()) {
-            return "loginForm";
-        }
-
-        loginService.login(loginForm.getLoginId(), loginForm.getPassword());
-
-        return "redirect:" + redirectURL;
-    }
-
-    @PostMapping("/logout")
-    public String logout(HttpServletRequest request) {
-        loginService.logout();
-
-        return "redirect:/";
     }
 }

--- a/src/main/java/spring/board/controller/MemberController.java
+++ b/src/main/java/spring/board/controller/MemberController.java
@@ -15,12 +15,10 @@ import spring.board.controller.form.PasswordEditForm;
 import spring.board.domain.member.Member;
 import spring.board.service.MemberService;
 
-import javax.validation.Valid;
-
 import static spring.board.controller.dto.MemberDto.*;
 
-@Controller
 @RequiredArgsConstructor
+@Controller
 public class MemberController {
 
     private final MemberService memberService;
@@ -32,18 +30,18 @@ public class MemberController {
 
     @PostMapping("/members/new")
     public String createMember(@Validated MemberForm memberForm, BindingResult bindingResult) {
-
         if(bindingResult.hasErrors()) {
             return "/members/createMemberForm";
         }
 
-        SaveRequest member = SaveRequest.builder()
+        MemberSaveRequest saveRequest = MemberSaveRequest.builder()
+                .email(memberForm.getEmail())
                 .loginId(memberForm.getLoginId())
                 .password(memberForm.getPassword())
                 .nickname(memberForm.getNickname())
                 .build();
 
-        memberService.join(member);
+        memberService.save(saveRequest);
         return "redirect:/";
     }
 
@@ -66,43 +64,10 @@ public class MemberController {
         return "members/createEditForm";
     }
 
-    @PostMapping("members/{loginId}/edit")
-    public String editMemberInfo(@PathVariable String loginId,
-                                 @Valid @ModelAttribute(name = "member") MemberEditForm memberEditForm, BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            return "members/createEditForm";
-        }
-
-        EditMemberInfoRequest member = EditMemberInfoRequest.builder()
-                .loginId(memberEditForm.getLoginId())
-                .nickname(memberEditForm.getNickname())
-                .build();
-        memberService.updateNickname(member);
-
-        return "redirect:/members/{loginId}/myPage";
-    }
-
     @GetMapping("members/{loginId}/edit/password")
     public String createPasswordEditForm(@PathVariable String loginId,
             @ModelAttribute(name = "passwordForm") PasswordEditForm passwordEditForm) {
         passwordEditForm.setLoginId(loginId);
         return "members/createPasswordEditForm";
-    }
-
-    @PostMapping("members/{loginId}/edit/password")
-    public String editPassword(@PathVariable String loginId,
-                               @Valid @ModelAttribute(name = "passwordForm") PasswordEditForm passwordEditForm, BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            return "members/createPasswordEditForm";
-        }
-
-        ChangePasswordRequest passwordRequest = ChangePasswordRequest.builder()
-                .loginId(loginId)
-                .prevPassword(passwordEditForm.getPrevPassword())
-                .afterPassword(passwordEditForm.getAfterPassword())
-                .build();
-        memberService.updatePassword(loginId, passwordRequest);
-
-        return "redirect:/members/{loginId}/myPage";
     }
 }

--- a/src/main/java/spring/board/controller/PostController.java
+++ b/src/main/java/spring/board/controller/PostController.java
@@ -21,8 +21,10 @@ import static spring.board.controller.dto.PostDto.*;
 @Slf4j
 @RequestMapping("/posts")
 public class PostController {
+
     private final PostService postService;
     private final ReplyService replyService;
+
     @GetMapping("/new")
     public String createPostForm(@ModelAttribute(name = "postForm") PostForm postForm) {
         return "posts/createPostForm";

--- a/src/main/java/spring/board/controller/api/member/MemberApiController.java
+++ b/src/main/java/spring/board/controller/api/member/MemberApiController.java
@@ -1,0 +1,40 @@
+package spring.board.controller.api.member;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import spring.board.service.MemberService;
+
+import static spring.board.controller.dto.MemberDto.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+@RestController
+public class MemberApiController {
+
+    private final MemberService memberService;
+
+    private final AuthenticationManager authenticationManager;
+
+    @PutMapping("/{loginId}")
+    public Long updateNickname(@RequestBody MemberUpdateRequest requestDto, @PathVariable String loginId) {
+        return memberService.updateNickname(requestDto, loginId);
+    }
+
+    @PutMapping("/{loginId}/password")
+    public Long updatePassword(@RequestBody PasswordUpdateRequest requestDto, @PathVariable String loginId) {
+        Long id =  memberService.updatePassword(loginId, requestDto);
+
+        Authentication authenticate = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginId, requestDto.getAfterPassword())
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authenticate);
+
+        return id;
+    }
+}

--- a/src/main/java/spring/board/controller/api/post/PostApiController.java
+++ b/src/main/java/spring/board/controller/api/post/PostApiController.java
@@ -1,28 +1,34 @@
-package spring.board.controller.api;
+package spring.board.controller.api.post;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import spring.board.common.annotation.LoginCheck;
-import spring.board.controller.dto.PostDto;
 import spring.board.domain.member.Member;
 import spring.board.service.PostService;
 import spring.board.service.ReplyService;
 import static spring.board.controller.dto.PostDto.*;
 import static spring.board.controller.dto.ReplyDto.*;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/posts")
 @RestController
 public class PostApiController {
+
     private final PostService postService;
+
     private final ReplyService replyService;
+
     @PostMapping("/new")
     public Long save(@RequestBody PostSaveRequest requestDto,
                      @LoginCheck Member member) {
+
         return postService.save(requestDto, member.getNickname());
     }
+
     @PutMapping("/{id}")
     public Long update(@RequestBody PostUpdateRequest requestDto) {
         return postService.update(requestDto);
     }
+
     @DeleteMapping("/{id}")
     public Long delete(@PathVariable Long id) {
         return postService.delete(id);

--- a/src/main/java/spring/board/controller/dto/MemberDto.java
+++ b/src/main/java/spring/board/controller/dto/MemberDto.java
@@ -2,6 +2,7 @@ package spring.board.controller.dto;
 
 import lombok.*;
 import spring.board.domain.member.Member;
+import spring.board.domain.member.Role;
 
 public class MemberDto {
 
@@ -28,41 +29,46 @@ public class MemberDto {
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
-    public static class SaveRequest {
+    public static class MemberSaveRequest {
 
+        private String email;
         private String loginId;
         private String password;
         private String nickname;
+        private Role role;
+
+        public void encodingPassword(String password) {
+            this.password = password;
+        }
 
         @Builder
-        public SaveRequest(String loginId, String password, String nickname) {
+        public MemberSaveRequest(String email, String loginId, String password, String nickname) {
+            this.email = email;
             this.loginId = loginId;
             this.password = password;
             this.nickname = nickname;
+            this.role = Role.USER;
         }
 
         public Member toEntity() {
             return Member.builder()
-                    .loginId(this.loginId)
-                    .password(this.password)
-                    .nickname(this.nickname)
+                    .email(email)
+                    .loginId(loginId)
+                    .password(password)
+                    .nickname(nickname)
+                    .role(role)
                     .build();
         }
     }
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
-    public static class ChangePasswordRequest {
-
-        private String loginId;
-
+    public static class PasswordUpdateRequest {
         private String prevPassword;
         private String afterPassword;
 
         @Builder
-        public ChangePasswordRequest(String loginId,
-                                     String prevPassword, String afterPassword) {
-            this.loginId = loginId;
+        public PasswordUpdateRequest(String prevPassword, String afterPassword) {
             this.prevPassword = prevPassword;
             this.afterPassword = afterPassword;
         }
@@ -70,14 +76,12 @@ public class MemberDto {
 
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
-    public static class EditMemberInfoRequest {
+    public static class MemberUpdateRequest {
 
-        private String loginId;
         private String nickname;
 
         @Builder
-        public EditMemberInfoRequest(String loginId, String nickname) {
-            this.loginId = loginId;
+        public MemberUpdateRequest(String nickname) {
             this.nickname = nickname;
         }
     }

--- a/src/main/java/spring/board/controller/form/MemberForm.java
+++ b/src/main/java/spring/board/controller/form/MemberForm.java
@@ -8,6 +8,8 @@ import javax.validation.constraints.NotEmpty;
 @Getter @Setter
 public class MemberForm {
 
+    @NotEmpty(message = "이메일은 필수로 입력해야 합니다.")
+    private String email;
     @NotEmpty(message = "아이디는 필수로 입력해야 합니다.")
     private String loginId;
     @NotEmpty(message = "비밀번호는 필수로 입력해야 합니다.")

--- a/src/main/java/spring/board/domain/member/Member.java
+++ b/src/main/java/spring/board/domain/member/Member.java
@@ -1,37 +1,42 @@
 package spring.board.domain.member;
 
 import lombok.*;
+import spring.board.domain.BaseTimeEntity;
 import spring.board.domain.MyPage;
 import spring.board.domain.post.Post;
 import spring.board.domain.reply.Reply;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotEmpty;
 import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 
-@Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Member {
+@Entity
+public class Member extends BaseTimeEntity {
 
     @Id @GeneratedValue
-    @Column(name = "member_id")
+    @Column(name = "member_id", nullable = false)
     private Long id;
 
-    @Column(unique = true)
-    @NotEmpty
+    @Column(unique = true, nullable = false)
     private String loginId;
 
-    @NotEmpty
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
     private String password;
 
-    @NotEmpty
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "my_page_id")
@@ -60,10 +65,11 @@ public class Member {
     }
 
     @Builder
-    public Member(Long id, String loginId, String password, String nickname) {
-        this.id = id;
+    public Member(String email, String loginId, String password, String nickname, Role role) {
+        this.email = email;
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
+        this.role = role;
     }
 }

--- a/src/main/java/spring/board/domain/member/MemberDetails.java
+++ b/src/main/java/spring/board/domain/member/MemberDetails.java
@@ -1,0 +1,51 @@
+package spring.board.domain.member;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@AllArgsConstructor
+public class MemberDetails implements UserDetails {
+
+    private Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(() -> "ROLE_" + member.getRole());
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/spring/board/domain/member/MemberRepository.java
+++ b/src/main/java/spring/board/domain/member/MemberRepository.java
@@ -11,8 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
 
-    Optional<Member> findByLoginIdAndPassword(String loginId, String password);
-
     Optional<Member> findByNickname(String nickname);
 
     boolean existsByLoginId(String loginId);

--- a/src/main/java/spring/board/domain/member/Role.java
+++ b/src/main/java/spring/board/domain/member/Role.java
@@ -1,0 +1,15 @@
+package spring.board.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String value;
+
+    Role(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/spring/board/service/LoginService.java
+++ b/src/main/java/spring/board/service/LoginService.java
@@ -1,34 +1,39 @@
 package spring.board.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.board.common.SessionConst;
 import spring.board.domain.member.Member;
+import spring.board.domain.member.MemberDetails;
 import spring.board.exception.member.CredentialException;
 import spring.board.domain.member.MemberRepository;
+import spring.board.exception.member.UserNotFoundException;
 
 import javax.servlet.http.HttpSession;
+
+import java.util.ArrayList;
 
 import static spring.board.common.SessionConst.*;
 
 @RequiredArgsConstructor
 @Service
-public class LoginService {
+public class LoginService implements UserDetailsService {
 
     private final HttpSession session;
     private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
-    public void login(String loginId, String password) {
-        Member member = memberRepository.findByLoginIdAndPassword(loginId, password)
-                .orElseThrow(() -> CredentialException.createCredentialException());
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("찾으려는 회원이 없습니다. : " + loginId));
 
         session.setAttribute(SESSION_LOGIN, member);
-    }
-
-    public void logout() {
-        session.removeAttribute(SESSION_LOGIN);
+        return new MemberDetails(member);
     }
 
     public Member getLoginMember() {

--- a/src/main/java/spring/board/service/MemberService.java
+++ b/src/main/java/spring/board/service/MemberService.java
@@ -1,41 +1,47 @@
 package spring.board.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spring.board.common.SessionConst;
 import spring.board.controller.dto.MemberDto;
-import spring.board.controller.dto.MemberDto.ChangePasswordRequest;
-import spring.board.controller.dto.MemberDto.SaveRequest;
+import spring.board.controller.dto.MemberDto.PasswordUpdateRequest;
+import spring.board.controller.dto.MemberDto.MemberSaveRequest;
 import spring.board.domain.member.Member;
 import spring.board.exception.member.DuplicatedMemberException;
 import spring.board.exception.member.UnauthenticatedUserException;
 import spring.board.exception.member.UserNotFoundException;
 import spring.board.domain.member.MemberRepository;
 
-@Service
+import javax.servlet.http.HttpSession;
+
+import static spring.board.common.SessionConst.*;
+
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    /**
-     * 회원 가입
-     */
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    private final HttpSession session;
+
     @Transactional
-    public void join(SaveRequest saveRequestDto) {
-        if (memberRepository.existsByLoginId(saveRequestDto.getLoginId())) {
+    public Long save(MemberSaveRequest requestDto) {
+        if (memberRepository.existsByLoginId(requestDto.getLoginId())) {
             throw DuplicatedMemberException.createDuplicatedMemberException();
         }
-
-        Member member = saveRequestDto.toEntity();
+        
+        requestDto.encodingPassword(passwordEncoder.encode(requestDto.getPassword()));
+        Member member = requestDto.toEntity();
         member.addMyPage();
         memberRepository.save(member);
+        return member.getId();
     }
 
-    /**
-     * 아이디로 회원 조회
-     */
     public Member findByLoginId(String loginId) {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UserNotFoundException("해당 아이디를 가진 회원이 존재하지 않습니다."));
@@ -43,37 +49,34 @@ public class MemberService {
         return member;
     }
 
-    public Member findById(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException("해당 회원이 존재하지 않습니다."));
-
-        return member;
-    }
-
     @Transactional
-    public void updateNickname(MemberDto.EditMemberInfoRequest editMemberInfoRequest) {
-        String loginId = editMemberInfoRequest.getLoginId();
-        String changedNickname = editMemberInfoRequest.getNickname();
+    public Long updateNickname(MemberDto.MemberUpdateRequest requestDto, String loginId) {
+        String nickname = requestDto.getNickname();
 
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UserNotFoundException("해당 아이디를 가진 회원이 존재하지 않습니다."));
 
-        member.updateNickname(changedNickname);
+        member.updateNickname(nickname);
+
+        session.setAttribute(SESSION_LOGIN, member);
+        return member.getId();
     }
 
     @Transactional
-    public void updatePassword(String loginId, ChangePasswordRequest changePasswordRequest) {
-        String prevPassword = changePasswordRequest.getPrevPassword();
-        String afterPassword = changePasswordRequest.getAfterPassword();
+    public Long updatePassword(String loginId, PasswordUpdateRequest requestDto) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UserNotFoundException("해당 아이디를 가진 회원이 존재하지 않습니다."));
 
-        if (!memberRepository.existsByLoginIdAndPassword(loginId, prevPassword)) {
+        if (passwordEncoder.matches(member.getPassword(), requestDto.getPrevPassword())) {
             throw new UnauthenticatedUserException("이전 비밀번호가 일치하지 않습니다.");
         }
 
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new UserNotFoundException("해당 아이디를 가진 회원이 존재하지 않습니다."));
+        String afterPassword = passwordEncoder.encode(
+                requestDto.getAfterPassword());
 
         member.updatePassword(afterPassword);
-    }
 
+        session.setAttribute(SESSION_LOGIN, member);
+        return member.getId();
+    }
 }

--- a/src/main/resources/static/js/member.js
+++ b/src/main/resources/static/js/member.js
@@ -1,0 +1,56 @@
+var main = {
+    init: function () {
+        var _this = this;
+
+        $('#update-member').on('click', function () {
+            _this.updateMember();
+        });
+
+        $('#update-password').on('click', function () {
+            _this.updatePassword();
+        })
+    },
+    updateMember: function() {
+      var data = {
+          nickname: $('#nickname').val()
+      };
+
+      var loginId = $('#loginId').val();
+
+      $.ajax({
+          type: 'PUT',
+          url: '/api/members/' + loginId,
+          dataType: 'json',
+          contentType:'application/json; charset=utf-8',
+          data: JSON.stringify(data)
+      }).done(function () {
+          alert('정상적으로 수정되었습니다.');
+          window.location.href = '/members/' + loginId + '/myPage';
+      }).fail(function (error) {
+          alert(JSON.stringify(error));
+      })
+    },  // update member
+    updatePassword: function () {
+        var data = {
+            prevPassword: $('#prevPassword').val(),
+            afterPassword: $('#afterPassword').val()
+        };
+
+        var loginId = $('#loginId').val();
+
+        $.ajax({
+            type: 'PUT',
+            url: '/api/members/' + loginId + '/password',
+            dataType: 'json',
+            contentType: 'application/json; charset=utf-8',
+            data: JSON.stringify(data)
+        }).done(function() {
+            alert('정상적으로 수정되었습니다.');
+            window.location.href = '/members/' + loginId + '/myPage';
+        }).fail(function(error) {
+            alert(JSON.stringify(error));
+        })
+    }   // update password
+}
+
+main.init();

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -4,12 +4,14 @@
 
 <body>
 <div class="container">
+
     <div class="py-5 text-center">
         <h3>게시판</h3>
     </div>
 
-    <div class="rightContainer justify-content-end">
+    <div>
         <div th:if="${member != null}">
+            <div class="float-start mx-lg-1 m-1" th:text="|${member.nickname} 님 안녕하세요!|"></div>
             <a class="btn btn-primary float-end mx-lg-2 m-1" th:href="@{members/{loginId}/myPage(loginId = ${member.loginId})}">마이 페이지</a>
             <form action="/logout" method="post">
                 <button class="btn btn-primary float-end mx-lg-2 m-1">로그아웃</button>
@@ -21,7 +23,7 @@
         </div>
     </div>
 
-    <div>
+    <div class="mb-4">
         <table class="table table-hover">
             <thead>
             <tr>

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -14,14 +14,14 @@
         <form role="form" action="/login" th:object="${loginForm}" method="post">
             <div>
                 <label for="loginId"></label>
-                <input id="loginId" th:field="*{loginId}"
+                <input id="loginId" th:field="*{loginId}" name="loginId"
                        th:errorclass="field-error"
                        class="form-control" placeholder="아이디를 입력해주세요" />
                 <div class="field-error" th:errors="*{loginId}">아이디는 필수로 입력해주세요</div>
             </div>
             <div>
                 <label for="password"></label>
-                <input type="password" id="password" th:field="*{password}"
+                <input type="password" id="password" th:field="*{password}" name="password"
                        th:errorclass="field-error"
                        class="form-control" placeholder="비밀번호를 입력해주세요" />
                 <div class="field-error" th:errors="*{password}">비밀번호는 필수로 입력해주세요</div>

--- a/src/main/resources/templates/members/createEditForm.html
+++ b/src/main/resources/templates/members/createEditForm.html
@@ -17,7 +17,7 @@
     <form role="form" th:object="${member}" th:action="@{/members/{loginId}/edit(loginId = ${member.loginId})}" th:method="post">
         <div>
             <label for="loginId">아이디</label>
-            <input id="loginId" class="form-control" th:placeholder="${loginId}" disabled />
+            <input id="loginId" class="form-control" th:value="${loginId}" th:placeholder="${loginId}" disabled />
         </div>
         <div>
             <label for="nickname">닉네임</label>
@@ -26,18 +26,20 @@
                    class="form-control" placeholder="닉네임을 입력해주세요" />
             <div th:errors="*{nickname}" class="field-error">닉네임 오류</div>
         </div>
-        <div class="row mt-3">
-            <div class="col">
-                <button class="w-100 btn btn-primary btn-lg" type="submit">수정</button>
-            </div>
-            <div class="col">
-                <button class="w-100 btn btn-secondary btn-lg" onclick="location.href='home.html'"
-                        th:onclick="|location.href='@{/members/{loginId}/myPage(loginId = ${member.loginId})}'|" type="button">취소</button>
-            </div>
-        </div>
     </form>
+    <div class="row mt-3">
+        <div class="col">
+            <button class="w-100 btn btn-primary btn-lg" id="update-member">수정</button>
+        </div>
+        <div class="col">
+            <a class="w-100 btn btn-secondary btn-lg" th:href="|@{/members/{loginId}/myPage(loginId = ${member.loginId})}|"
+               type="button">취소</a>
+        </div>
+    </div>
 
     <footer th:replace="fragments/footer :: footer" />
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="/js/member.js"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/members/createMemberForm.html
+++ b/src/main/resources/templates/members/createMemberForm.html
@@ -8,6 +8,13 @@
     </div>
     <form role="form" action="/members/new" th:object="${memberForm}" method="post">
         <div>
+            <label for="email">이메일</label>
+            <input type="text" id="email" th:field="*{email}"
+                   th:errorclass="field-error"
+                   class="form-control" placeholder="이메일을 입력해주세요" />
+            <div th:errors="*{email}" class="field-error">이메일 오류</div>
+        </div>
+        <div>
             <label for="loginId">아아디</label>
             <input type="text" id="loginId" th:field="*{loginId}"
                    th:errorclass="field-error"

--- a/src/main/resources/templates/members/createPasswordEditForm.html
+++ b/src/main/resources/templates/members/createPasswordEditForm.html
@@ -17,34 +17,36 @@
     <form role="form" th:object="${passwordForm}" th:action="@{/members/{loginId}/edit/password(loginId = ${passwordForm.loginId})}" th:method="post">
         <div>
             <label for="loginId">아이디</label>
-            <input id="loginId" class="form-control" th:placeholder="${loginId}" disabled />
+            <input id="loginId" class="form-control" th:value="${loginId}" th:placeholder="${loginId}" disabled />
         </div>
         <div>
             <label for="prevPassword">이전 비밀번호</label>
-            <input type="text" id="prevPassword" th:field="*{prevPassword}"
+            <input type="password" id="prevPassword" th:field="*{prevPassword}"
                    th:errorclass="field-error"
                    class="form-control" placeholder="이전 비밀번호를 입력해주세요" />
             <div th:errors="*{prevPassword}" class="field-error">비밀번호 오류</div>
         </div>
         <div>
             <label for="afterPassword">신규 비밀번호</label>
-            <input type="text" id="afterPassword" th:field="*{afterPassword}"
+            <input type="password" id="afterPassword" th:field="*{afterPassword}"
                    th:errorclass="field-error"
                    class="form-control" placeholder="새로운 비밀번호를 입력해주세요" />
             <div th:errors="*{afterPassword}" class="field-error">비밀번호 오류</div>
         </div>
-        <div class="row mt-3">
-            <div class="col">
-                <button class="w-100 btn btn-primary btn-lg" type="submit">수정</button>
-            </div>
-            <div class="col">
-                <button class="w-100 btn btn-secondary btn-lg" onclick="location.href='home.html'"
-                        th:onclick="|location.href='@{/members/{loginId}/myPage(loginId = ${passwordForm.loginId})}'|" type="button">취소</button>
-            </div>
-        </div>
     </form>
-
+    <div class="row mt-3">
+        <div class="col">
+            <button class="w-100 btn btn-primary btn-lg"
+                    id="update-password">수정</button>
+        </div>
+        <div class="col">
+            <a class="w-100 btn btn-secondary btn-lg" th:href="|@{/members/{loginId}/myPage(loginId = ${passwordForm.loginId})}|"
+               type="button">취소</a>
+        </div>
+    </div>
     <footer th:replace="fragments/footer :: footer" />
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="/js/member.js"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/members/my-page/myPage.html
+++ b/src/main/resources/templates/members/my-page/myPage.html
@@ -19,7 +19,7 @@
     </div>
 
     <div>
-        <div class="row">
+        <div class="row mb-4">
             <div class="col">
                 <a type="submit" class="w-100 btn btn-primary" th:href="@{/members/{loginId}/edit(loginId = ${member.loginId})}">내 정보 수정하기</a>
             </div>
@@ -27,9 +27,9 @@
                 <button type="button" class="w-100 btn btn-secondary" th:onclick="|location.href='@{/}'|">홈으로</button>
             </div>
         </div>
-        <div class="row mt-0">
+        <div class="row mt-4">
             <div class="col">
-                <button class="w-100 btn btn-light btn-lg" onclick="location.href='createPasswordEditForm.html'"
+                <button class="w-100 btn btn-outline-primary btn-lg" onclick="location.href='createPasswordEditForm.html'"
                         th:onclick="|location.href='@{/members/{loginId}/edit/password(loginId = ${member.loginId})}'|">비밀번호 수정</button>
             </div>
         </div>

--- a/src/test/java/spring/board/service/MemberServiceTest.java
+++ b/src/test/java/spring/board/service/MemberServiceTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import spring.board.controller.dto.MemberDto.SaveRequest;
+import spring.board.controller.dto.MemberDto.MemberSaveRequest;
 import spring.board.domain.member.Member;
 import spring.board.exception.member.DuplicatedMemberException;
 import spring.board.exception.member.UserNotFoundException;
@@ -23,78 +23,4 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
-
-    @InjectMocks
-    private MemberService memberService;
-
-    @Test
-    public void 회원가입_성공() {
-        // given
-        SaveRequest saveRequest = createMemberDto();
-        Member member = saveRequest.toEntity();
-        given(memberRepository.findByLoginId(saveRequest.getLoginId()))
-                .willReturn(Optional.of(member));
-
-        // when
-        memberService.join(saveRequest);
-
-        // then
-        assertThat(Optional.of(member)).isEqualTo(memberRepository.findByLoginId(saveRequest.getLoginId()));
-    }
-
-    @DisplayName("중복된 로그인 아이디로 인해 회원가입이 실패한다.")
-    @Test
-    public void 회원가입_실패() {
-        // given
-        SaveRequest saveRequest = createMemberDto();
-        Member member = createMember();
-        given(memberRepository.existsByLoginId(member.getLoginId()))
-                .willReturn(true);
-
-        // when
-        // then
-        assertThrows(DuplicatedMemberException.class, () -> memberService.join(saveRequest));
-        then(memberRepository).should(times(0)).save(member);
-    }
-
-    @Test
-    public void 로그인아이디_회원조회() {
-        // given
-        Member member = createMember();
-        given(memberRepository.findByLoginId(member.getLoginId()))
-                .willReturn(Optional.of(member));
-
-        // when
-        Member findMember = memberService.findByLoginId(member.getLoginId());
-
-        // then
-        assertThat(member).isEqualTo(findMember);
-        then(memberRepository).should(times(1)).findByLoginId(member.getLoginId());
-    }
-
-    @DisplayName("로그인아이디를 통해 조회한 회원이 없어서 실패한다.")
-    @Test
-    public void 로그인아이디_회원조회_실패() {
-        // given
-        Member member = createMember();
-
-        // when
-        // then
-        assertThrows(UserNotFoundException.class, () -> memberService.findByLoginId(member.getLoginId()));
-        then(memberRepository).should(times(1)).findByLoginId(member.getLoginId());
-    }
-
-    private SaveRequest createMemberDto() {
-        return SaveRequest.builder()
-                .loginId("loginId")
-                .password("testPassword")
-                .nickname("nickname")
-                .build();
-    }
-
-    private Member createMember() {
-        return createMemberDto().toEntity();
-    }
 }


### PR DESCRIPTION
# Motivations
- Member 엔티티와 관련된 회원정보 변경 로직 및 비밀번호 변경 로직 수정했습니다.
- Spring Security를 적용해 로그인 과정을 처리했습니다.

# Key Changes
- Authentication(UsernamePasswordAuthenticationToken)의 구성
    - principal : String loginId
    - credential : String password
    - authorities : Collection authorities를 두고 ROLE_USER를 추가
- 로그인 상태에서 회원 정보 수정시 Session의 Member도 함께 수정

# To Reviewers
- Spring Security 필터의 흐름에 학습이 더 필요합니다.
- BCrypt encoder 사용 시 matches 함수를 이용해 비밀번호를 확인해야 함을 알았습니다.
    - 입력값이 같아도 매번 출력물이 다르기 때문입니다.
