### PR TITLE
해시태그 검색 페이지와 관련 기능 구현

### DIFF
--- a/src/main/java/spring/board/controller/ArticleController.java
+++ b/src/main/java/spring/board/controller/ArticleController.java
@@ -51,4 +51,23 @@ public class ArticleController {
         map.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
+
+    @GetMapping("/search-hashtag")
+    public String searchArticlesByHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable)
+                .map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
+    }
 }

--- a/src/main/java/spring/board/domain/article/ArticleRepository.java
+++ b/src/main/java/spring/board/domain/article/ArticleRepository.java
@@ -9,10 +9,12 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import spring.board.domain.article.querydsl.ArticleRepositoryCustom;
 
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle> {
 

--- a/src/main/java/spring/board/domain/article/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/spring/board/domain/article/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,8 @@
+package spring.board.domain.article.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+
+    List<String> findAllDistinctHashtags();
+}

--- a/src/main/java/spring/board/domain/article/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/spring/board/domain/article/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package spring.board.domain.article.querydsl;
+
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import spring.board.domain.article.Article;
+import spring.board.domain.article.QArticle;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+
+        return from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.isNotNull())
+                .fetch();
+    }
+}

--- a/src/main/java/spring/board/service/ArticleService.java
+++ b/src/main/java/spring/board/service/ArticleService.java
@@ -14,6 +14,7 @@ import spring.board.domain.article.ArticleRepository;
 import spring.board.dto.ArticleWithCommentsDto;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -75,5 +76,17 @@ public class ArticleService {
 
     public long getArticleCount() {
         return articleRepository.count();
+    }
+
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if (hashtag == null || hashtag.isBlank()) {
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
     }
 }

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>해시태그 검색</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+    <header id="header">
+        헤더 삽입부
+        <hr>
+    </header>
+
+    <main class="container">
+        <header class="py-5 text-center">
+            <h1>Hashtags</h1>
+        </header>
+
+        <section class="row">
+            <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+                <div class="p-2">
+                    <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+                </div>
+            </div>
+        </section>
+
+        <hr>
+
+        <table class="table" id="article-table">
+            <thead>
+            <tr>
+                <th class="title col-6"><a>제목</a></th>
+                <th class="content col-4"><a>본문</a></th>
+                <th class="user-id"><a>작성자</a></th>
+                <th class="created-at"><a>작성일</a></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="title"><a>첫글</a></td>
+                <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+                <td class="user-id">Uno</td>
+                <td class="created-at"><time>2022-01-01</time></td>
+            </tr>
+            <tr>
+                <td>두번째글</td>
+                <td>본문</td>
+                <td>Uno</td>
+                <td><time>2022-01-02</time></td>
+            </tr>
+            <tr>
+                <td>세번째글</td>
+                <td>본문</td>
+                <td>Uno</td>
+                <td><time>2022-01-03</time></td>
+            </tr>
+            </tbody>
+        </table>
+
+        <nav id="pagination" aria-label="Page navigation">
+            <ul class="pagination justify-content-center">
+                <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+                <li class="page-item"><a class="page-link" href="#">1</a></li>
+                <li class="page-item"><a class="page-link" href="#">Next</a></li>
+            </ul>
+        </nav>
+
+    </main>
+
+    <footer id="footer">
+        <hr>
+        footer 삽입부
+    </footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="fragments/header :: header" />
+    <attr sel="#footer" th:replace="fragments/footer :: footer" />
+
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+            </attr>
+        </attr>
+
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:text="'previous'"
+                      th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                    <attr sel="a"
+                          th:text="${pageNumber + 1}"
+                          th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                    />
+                </attr>
+                <attr sel="li[2]/a"
+                      th:text="'next'"
+                      th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>

--- a/src/test/java/spring/board/service/ArticleServiceTest.java
+++ b/src/test/java/spring/board/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import spring.board.dto.UserAccountDto;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -63,6 +64,36 @@ class ArticleServiceTest {
         // Then
         assertThat(articles).isEmpty();
         then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
+    }
+
+    @DisplayName("검색어 없이 게시글을 해시태그를 통해 검색하면, 빈 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticlesViaHashtag_thenReturnsEmptyPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(null, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글을 해시태그를 통해 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenHashtag_whenSearchingArticlesViaHashtag_thenReturnsArticlesPage() {
+        // Given
+        String hashtag = "#Java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtag, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag, pageable);
     }
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
@@ -175,6 +206,21 @@ class ArticleServiceTest {
         // then
         assertThat(actual).isEqualTo(expected);
         then(articleRepository).should().count();
+    }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void givenNoting_whenCalling_thenReturnsHashtags() {
+        // given
+        List<String> expected = List.of("#Java", "#Spring", "#Boot");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expected);
+
+        // when
+        List<String> actual = sut.getHashtags();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().findAllDistinctHashtags();
     }
 
 


### PR DESCRIPTION
- QueryDSL 사용
    - 해시태그 뷰에 모든 게시글에 등장하는 해시태그를 정리해서 보여주는 기능을 추가
- 서비스, 컨트롤러 관련 테스트 코드 작성
- 뷰에 기능 추가
    - 검색 가능한 해시태그 리스틀 사용자에게 보여줌

This closes #42 