### PR TITLE
게시글 뷰 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,14 +41,14 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
-    
+
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    compileOnly 'org.springframework.boot:spring-boot-devtools'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+    
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.springframework.boot:spring-boot-devtools'
 }

--- a/src/main/java/spring/board/common/config/SecurityConfig.java
+++ b/src/main/java/spring/board/common/config/SecurityConfig.java
@@ -3,8 +3,10 @@ package spring.board.common.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+@EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 

--- a/src/main/java/spring/board/controller/ArticleController.java
+++ b/src/main/java/spring/board/controller/ArticleController.java
@@ -8,7 +8,11 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
-import spring.board.domain.article.SearchType;
+import spring.board.domain.constants.FormStatus;
+import spring.board.domain.constants.SearchType;
+import spring.board.dto.ArticleDto;
+import spring.board.dto.UserAccountDto;
+import spring.board.dto.request.ArticleRequest;
 import spring.board.dto.response.ArticleResponse;
 import spring.board.dto.response.ArticleWithCommentsResponse;
 import spring.board.service.ArticleService;
@@ -45,7 +49,7 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     public String getArticleInfo(@PathVariable Long articleId, ModelMap map) {
-        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticleWithComments(articleId));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponses());
         map.addAttribute("totalCount", articleService.getArticleCount());
@@ -69,5 +73,50 @@ public class ArticleController {
         map.addAttribute("searchType", SearchType.HASHTAG);
 
         return "articles/search-hashtag";
+    }
+
+    @GetMapping("/form")
+    public String articleForm(ModelMap map) {
+        map.addAttribute("formStatus", FormStatus.CREATE);
+
+        return "articles/form";
+    }
+
+    @PostMapping("/form")
+    public String postNewArticle(ArticleRequest articleRequest) {
+        // TODO: 인증정보를 넣어줘야 한다.
+        articleService.saveArticle(articleRequest.toDto(
+                UserAccountDto.of("23Yong", "23Yong@email.com", "password", "23Yong", "memo")
+        ));
+
+        return "redirect:/articles";
+    }
+
+    @GetMapping("/{articleId}/form")
+    public String updateArticleForm(@PathVariable Long articleId, ModelMap map) {
+        ArticleDto article = articleService.getArticle(articleId);
+
+        map.addAttribute("article", article);
+        map.addAttribute("formStatus", FormStatus.UPDATE);
+
+        return "articles/form";
+    }
+
+    @PostMapping("/{articleId}/form")
+    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
+        // TODO: 인증정보를 넣어줘야 한다.
+        ArticleDto dto = articleRequest.toDto(
+                UserAccountDto.of("23Yong", "23Yong@email.com", "password", "23Yong", "memo")
+        );
+        articleService.updateArticle(articleId, dto);
+
+        return "redirect:/articles/" + articleId;
+    }
+
+    @PostMapping("/{articleId}/delete")
+    public String deleteArticle(@PathVariable Long articleId) {
+        articleService.deleteArticle(articleId);
+
+        return "redirect:/articles";
     }
 }

--- a/src/main/java/spring/board/domain/constants/FormStatus.java
+++ b/src/main/java/spring/board/domain/constants/FormStatus.java
@@ -1,0 +1,17 @@
+package spring.board.domain.constants;
+
+import lombok.Getter;
+
+public enum FormStatus {
+
+    CREATE("저장", false),
+    UPDATE("수정", true);
+
+    @Getter private final String description;
+    @Getter private final boolean update;
+
+    FormStatus(String description, boolean update) {
+        this.description = description;
+        this.update = update;
+    }
+}

--- a/src/main/java/spring/board/domain/constants/SearchType.java
+++ b/src/main/java/spring/board/domain/constants/SearchType.java
@@ -1,4 +1,4 @@
-package spring.board.domain.article;
+package spring.board.domain.constants;
 
 import lombok.Getter;
 

--- a/src/main/java/spring/board/domain/member/UserAccountRepository.java
+++ b/src/main/java/spring/board/domain/member/UserAccountRepository.java
@@ -8,11 +8,5 @@ import java.util.Optional;
 @RepositoryRestResource
 public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
 
-    Optional<UserAccount> findByUserId(String userId);
-
-    Optional<UserAccount> findByNickname(String nickname);
-
-    Optional<UserAccount> findByEmail(String email);
-
-    boolean existsByUserId(String userId);
+    UserAccount getReferenceByUserId(String userId);
 }

--- a/src/main/java/spring/board/dto/ArticleDto.java
+++ b/src/main/java/spring/board/dto/ArticleDto.java
@@ -1,6 +1,7 @@
 package spring.board.dto;
 
 import spring.board.domain.article.Article;
+import spring.board.domain.member.UserAccount;
 
 import java.time.LocalDateTime;
 
@@ -20,6 +21,10 @@ public record ArticleDto(
         return new ArticleDto(id, userAccountDto, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
+    public static ArticleDto of(UserAccountDto userAccountDto, String title, String content, String hashtag) {
+        return new ArticleDto(null, userAccountDto, title, content, hashtag, null, null, null, null);
+    }
+
     public static ArticleDto from(Article entity) {
         return new ArticleDto(
                 entity.getId(),
@@ -34,9 +39,9 @@ public record ArticleDto(
         );
     }
 
-    public Article toEntity() {
+    public Article toEntity(UserAccount userAccount) {
         return Article.of(
-                userAccountDto.toEntity(),
+                userAccount,
                 title,
                 content,
                 hashtag

--- a/src/main/java/spring/board/dto/UserAccountDto.java
+++ b/src/main/java/spring/board/dto/UserAccountDto.java
@@ -16,6 +16,10 @@ public record UserAccountDto(
         String memo
 ) {
 
+    public static UserAccountDto of(String userId, String email, String userPassword, String nickname, String memo) {
+        return new UserAccountDto(null, null, null, null, userId, email, userPassword, nickname, memo);
+    }
+
     public static UserAccountDto of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String userId, String email, String userPassword, String nickname, String memo) {
         return new UserAccountDto(createdAt, createdBy, modifiedAt, modifiedBy, userId, email, userPassword, nickname, memo);
     }

--- a/src/main/java/spring/board/dto/request/ArticleRequest.java
+++ b/src/main/java/spring/board/dto/request/ArticleRequest.java
@@ -1,0 +1,24 @@
+package spring.board.dto.request;
+
+import spring.board.dto.ArticleDto;
+import spring.board.dto.UserAccountDto;
+
+public record ArticleRequest(
+        String title,
+        String content,
+        String hashtag
+) {
+
+    public static ArticleRequest of(String title, String content, String hashtag) {
+        return new ArticleRequest(title, content, hashtag);
+    }
+
+    public ArticleDto toDto(UserAccountDto userAccountDto) {
+        return ArticleDto.of(
+                userAccountDto,
+                title,
+                content,
+                hashtag
+        );
+    }
+}

--- a/src/main/java/spring/board/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/spring/board/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/spring/board/dto/response/ArticleResponse.java
+++ b/src/main/java/spring/board/dto/response/ArticleResponse.java
@@ -13,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/spring/board/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/spring/board/dto/response/ArticleWithCommentsResponse.java
@@ -17,7 +17,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponses
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -11,6 +11,12 @@
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
 
+        <attr sel="#article-buttons">
+            <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
+                <attr sel="#update-article" th:action="'/articles/' + *{form} + '/form'" />
+            </attr>
+        </attr>
+
         <attr sel="#article-comments" th:remove="all-but-first">
             <attr sel="li[0]" th:each="articleComment : ${articleCommentsResponses}">
                 <attr sel="div/strong" th:text="${articleComment.nickname}" />

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -13,7 +13,7 @@
 
         <attr sel="#article-buttons">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
-                <attr sel="#update-article" th:action="'/articles/' + *{form} + '/form'" />
+                <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
         </attr>
 

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>새 게시글 등록</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
+</head>
+
+<body>
+
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<div class="container">
+  <header id="article-form-header" class="py-5 text-center">
+    <h1>게시글 작성</h1>
+  </header>
+
+  <form id="article-form">
+    <div class="row mb-3 justify-content-md-center">
+      <label for="title" class="col-sm-2 col-lg-1 col-form-label text-sm-end">제목</label>
+      <div class="col-sm-8 col-lg-9">
+        <input type="text" class="form-control" id="title" name="title" required>
+      </div>
+    </div>
+    <div class="row mb-3 justify-content-md-center">
+      <label for="content" class="col-sm-2 col-lg-1 col-form-label text-sm-end">본문</label>
+      <div class="col-sm-8 col-lg-9">
+        <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
+      </div>
+    </div>
+    <div class="row mb-4 justify-content-md-center">
+      <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
+      <div class="col-sm-8 col-lg-9">
+        <input type="text" class="form-control" id="hashtag" name="hashtag">
+      </div>
+    </div>
+    <div class="row mb-5 justify-content-md-center">
+      <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
+        <button type="submit" class="btn btn-primary" id="submit-button">저장</button>
+        <button type="button" class="btn btn-secondary" id="cancel-button">취소</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<footer id="footer">
+  <hr>
+  푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="fragments/header :: header" />
+    <attr sel="#footer" th:replace="fragments/footer :: footer" />
+
+    <attr sel="#article-form-header/h1" th:text="${formStatus} ? '게시글 ' + ${formStatus.description} : _" />
+
+    <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
+        <attr sel="#title" th:value="${article?.title} ?: _" />
+        <attr sel="#content" th:text="${article?.content} ?: _" />
+        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
+        <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
+        <attr sel="#cancel-button" th:onclick="'history.back()'" />
+    </attr>
+</thlogic>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -5,6 +5,7 @@
 
     <attr sel="main" th:object="${articles}">
 
+        <attr sel="#search-form" th:action="@{/articles}" th:method="get" />
         <attr sel="#search-type" th:remove="all-but-first">
             <attr sel="option[0]"
                   th:each="searchType : ${searchTypes}"
@@ -50,6 +51,8 @@
                 </attr>
             </attr>
         </attr>
+
+        <attr sel="#write-article" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/main/resources/templates/sign-up.html
+++ b/src/main/resources/templates/sign-up.html
@@ -1,0 +1,23 @@
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>회원 가입</title>
+</head>
+<body>
+<header>
+    header 템플릿 삽입부
+    <hr>
+</header>
+<form>
+    <label for="userId">ID</label>
+    <input id="userId" type="text" required>
+    <label for="password">Password</label>
+    <input id="password" type="password" required>
+    <label for="email">Email</label>
+    <input id="email" type="email" placeholder="you@example.com">
+    <label for="nickname">Nickname</label>
+    <input id="nickname" type="text">
+    <label for="memo">메모</label>
+    <textarea id="memo" rows="3"></textarea>
+    <button type="submit">가입</button>
+</form>

--- a/src/test/java/spring/board/common/util/FormDataEncoder.java
+++ b/src/test/java/spring/board/common/util/FormDataEncoder.java
@@ -1,0 +1,32 @@
+package spring.board.common.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@TestComponent
+public class FormDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public FormDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public String encode(Object obj) {
+        Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
+        MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
+        valueMap.setAll(fieldMap);
+
+        return UriComponentsBuilder.newInstance()
+                .queryParams(valueMap)
+                .encode()
+                .build()
+                .getQuery();
+    }
+}

--- a/src/test/java/spring/board/common/util/FormDataEncoderTest.java
+++ b/src/test/java/spring/board/common/util/FormDataEncoderTest.java
@@ -1,0 +1,74 @@
+package spring.board.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("테스트 도구 - Form 데이터 인코더")
+@Import({FormDataEncoder.class, ObjectMapper.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class FormDataEncoderTest {
+
+    private final FormDataEncoder formDataEncoder;
+
+    public FormDataEncoderTest(@Autowired FormDataEncoder formDataEncoder) {
+        this.formDataEncoder = formDataEncoder;
+    }
+
+    @DisplayName("객체를 넣으면 url encoding 된 form body data 형식의 문자열을 돌려준다.")
+    @Test
+    void givenObject_whenEncoding_thenReturnsFormEncodedData() {
+        // given
+        TestObject obj = new TestObject(
+                "This 'is' \"test\" string.",
+                List.of("hello", "my", "friend").toString().replace(" ", ""),
+                String.join(",", "hello", "my", "friend"),
+                null,
+                1234,
+                3.14,
+                false,
+                BigDecimal.TEN,
+                TestEnum.THREE
+        );
+
+        // when
+        String result = formDataEncoder.encode(obj);
+
+        // then
+        assertThat(result).isEqualTo(
+                "str=This%20'is'%20%22test%22%20string." +
+                        "&listStr1=%5Bhello,my,friend%5D" +
+                        "&listStr2=hello,my,friend" +
+                        "&nullStr" +
+                        "&number=1234" +
+                        "&floatingNumber=3.14" +
+                        "&bool=false" +
+                        "&bigDecimal=10" +
+                        "&testEnum=THREE"
+        );
+    }
+
+    record TestObject(
+            String str,
+            String listStr1,
+            String listStr2,
+            String nullStr,
+            Integer number,
+            Double floatingNumber,
+            Boolean bool,
+            BigDecimal bigDecimal,
+            TestEnum testEnum
+    ) {}
+
+    enum TestEnum {
+        ONE, TWO, THREE
+    }
+}

--- a/src/test/java/spring/board/controller/ArticleControllerTest.java
+++ b/src/test/java/spring/board/controller/ArticleControllerTest.java
@@ -14,9 +14,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import spring.board.common.config.SecurityConfig;
-import spring.board.domain.article.SearchType;
+import spring.board.common.util.FormDataEncoder;
+import spring.board.domain.constants.FormStatus;
+import spring.board.domain.constants.SearchType;
+import spring.board.dto.ArticleDto;
 import spring.board.dto.ArticleWithCommentsDto;
 import spring.board.dto.UserAccountDto;
+import spring.board.dto.request.ArticleRequest;
 import spring.board.service.ArticleService;
 import spring.board.service.PaginationService;
 
@@ -26,23 +30,28 @@ import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 게시글")
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleController.class)
 class ArticleControllerTest {
 
     private final MockMvc mvc;
+    private final FormDataEncoder formDataEncoder;
 
     @MockBean
     private ArticleService articleService;
     @MockBean
     private PaginationService paginationService;
 
-    public ArticleControllerTest(@Autowired MockMvc mvc) {
+    public ArticleControllerTest(
+            @Autowired MockMvc mvc,
+            @Autowired FormDataEncoder formDataEncoder) {
         this.mvc = mvc;
+        this.formDataEncoder = formDataEncoder;
     }
 
     @DisplayName("[View] [GET] 게시글 리스트 (게시판) 페이지 - 정상호출")
@@ -97,7 +106,7 @@ class ArticleControllerTest {
         // given
         Long articeId = 1L;
         long totalCount = 1L;
-        given(articleService.getArticle(articeId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticleWithComments(articeId)).willReturn(createArticleWithCommentsDto());
         given(articleService.getArticleCount()).willReturn(totalCount);
 
         // when & then
@@ -109,21 +118,8 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articleComments"))
                 .andExpect(model().attribute("totalCount", totalCount));
 
-        then(articleService).should().getArticle(articeId);
+        then(articleService).should().getArticleWithComments(articeId);
         then(articleService).should().getArticleCount();
-    }
-
-    @Disabled
-    @DisplayName("[View] [GET] 게시글 검색 전용 페이지 - 정상호출")
-    @Test
-    void givenNothing_whenRequestingArticleSearchView_thenReturnsArticleSearchView() throws Exception {
-        // given
-
-        // when & then
-        mvc.perform(get("/articles/search"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("articles/search"));
     }
 
     @DisplayName("[View] [GET] 게시글 해시태그 검색 전용 페이지 - 정상호출")
@@ -204,6 +200,108 @@ class ArticleControllerTest {
         // then
         then(articleService).should().searchArticles(null, null, pageable);
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
+    }
+
+    @DisplayName("[view] [GET] 새 게시글 작성 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsNewArticlePage() throws Exception{
+        // given
+
+        // when & then
+        mvc.perform(get("/articles/form"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/form"))
+                .andExpect(model().attribute("formStatus", FormStatus.CREATE));
+    }
+
+    @DisplayName("[view] [GET] 새 게시글 등록 - 정상호출")
+    @Test
+    void givenNewArticleInfo_whenRequesting_thenSaveNewArticle() throws Exception{
+        // given
+        ArticleRequest articleRequest = ArticleRequest.of("new title", "new content", "#new");
+        willDoNothing().given(articleService).saveArticle(any(ArticleDto.class));
+
+        // when & then
+        mvc.perform(
+                post("/articles/form")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(articleRequest))
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles"))
+                .andExpect(redirectedUrl("/articles"));
+
+        then(articleService).should().saveArticle(any(ArticleDto.class));
+    }
+
+    @DisplayName("[view] [GET] 게시글 수정 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsUpdatedArticlePage() throws Exception {
+        // given
+        long articleId = 1L;
+        ArticleDto articleDto = createArticleDto();
+        given(articleService.getArticle(articleId)).willReturn(articleDto);
+
+        // when & then
+        mvc.perform(get("/articles/" + articleId + "/form"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("articles/form"))
+                .andExpect(model().attribute("article", articleDto))
+                .andExpect(model().attribute("formStatus", FormStatus.UPDATE));
+        then(articleService).should().getArticle(articleId);
+    }
+
+    @DisplayName("[view] [POST] 게시글 수정 - 정상 호출")
+    @Test
+    void givenUpdatedArticleInfo_whenRequesting_thenUpdatesNewArticle() throws Exception {
+        // given
+        long articleId = 1L;
+        ArticleRequest articleRequest = ArticleRequest.of("new title", "new content", "#new");
+        willDoNothing().given(articleService).updateArticle(eq(articleId), any(ArticleDto.class));
+
+        // when & then
+        mvc.perform(
+                post("/articles/" + articleId + "/form")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(articleRequest))
+                        .with(csrf())
+        )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+
+        then(articleService).should().updateArticle(eq(articleId), any(ArticleDto.class));
+    }
+
+    @DisplayName("[view][POST] 게시글 삭제 - 정상 호출")
+    @Test
+    void givenArticleIdToDelete_whenRequesting_thenDeletesArticle() throws Exception {
+        // Given
+        long articleId = 1L;
+        willDoNothing().given(articleService).deleteArticle(articleId);
+
+        // When & Then
+        mvc.perform(
+                        post("/articles/" + articleId + "/delete")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles"))
+                .andExpect(redirectedUrl("/articles"));
+
+        then(articleService).should().deleteArticle(articleId);
+    }
+
+    private ArticleDto createArticleDto() {
+        return ArticleDto.of(
+                createUserAccountDto(),
+                "title",
+                "content",
+                "#Java"
+        );
     }
 
     private ArticleWithCommentsDto createArticleWithCommentsDto() {

--- a/src/test/java/spring/board/service/ArticleServiceTest.java
+++ b/src/test/java/spring/board/service/ArticleServiceTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import spring.board.domain.article.Article;
-import spring.board.domain.article.SearchType;
+import spring.board.domain.constants.SearchType;
 import spring.board.domain.member.UserAccount;
 import spring.board.dto.ArticleDto;
 import spring.board.domain.article.ArticleRepository;
@@ -105,7 +105,7 @@ class ArticleServiceTest {
         given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
 
         // When
-        ArticleWithCommentsDto dto = sut.getArticle(articleId);
+        ArticleWithCommentsDto dto = sut.getArticleWithComments(articleId);
 
         // Then
         assertThat(dto)
@@ -123,7 +123,7 @@ class ArticleServiceTest {
         given(articleRepository.findById(articleId)).willReturn(Optional.empty());
 
         // When
-        Throwable t = catchThrowable(() -> sut.getArticle(articleId));
+        Throwable t = catchThrowable(() -> sut.getArticleWithComments(articleId));
 
         // Then
         assertThat(t)
@@ -155,7 +155,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
 
         // When
-        sut.updateArticle(dto);
+        sut.updateArticle(dto.id(), dto);
 
         // Then
         assertThat(article)
@@ -173,7 +173,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
 
         // When
-        sut.updateArticle(dto);
+        sut.updateArticle(dto.id(), dto);
 
         // Then
         then(articleRepository).should().getReferenceById(dto.id());


### PR DESCRIPTION
게시글의 등록, 수정, 삭제 기능을 추가

1. DTO 리팩토링
    - UserAccountDto의 AuditingField 들은 DB 영속화과정에서 자동으로 들어가기 때문에 null 처리
    - Serializable 인터페이스의 제거
        - 직렬화를 Jackson을 통해 수행하기 때문에 제거
2. UserId를 통해 UserAccount 를 찾을 수 있도록 설정
     - 게시글을 저장하는 과정에서 ArticleDto를 넘기는데, 이때 UserAccountDto의 userId를 통해 UserAccount로 넘기기 위해 사용
3. @EnableWebSecurity 추가
    - 현재 버그인지는 모르겠으나 @EnalbeWebSecurity를 추가하지 않으면 HttpSecurity 빈이 자동으로 주입이 안되는 문제 인식
    - https://github.com/okta/okta-spring-boot/issues/258
    - 추후 개선 예정

This closes #45 