### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 수정

### DIFF
--- a/src/main/java/spring/board/domain/article/Article.java
+++ b/src/main/java/spring/board/domain/article/Article.java
@@ -76,11 +76,11 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (!(o instanceof Article)) return false;
         Article article = (Article) o;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/spring/board/domain/articlecomment/ArticleComment.java
+++ b/src/main/java/spring/board/domain/articlecomment/ArticleComment.java
@@ -53,11 +53,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/spring/board/domain/member/UserAccount.java
+++ b/src/main/java/spring/board/domain/member/UserAccount.java
@@ -58,14 +58,14 @@ public class UserAccount extends AuditingFields {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(userId);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.userId);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.userId);
+    public int hashCode() {
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
프록시 객체를 다루는 하이버네이트의 특성을 고려하여 필드의 직접 접근이 아닌 getter로 수정해 값 비교를 제대로 하지 못하는 상황을 예방

This closes #66 
