### PR TITLE
[리팩토링] AuditingFields 의 잘못 표현된 부분 개선

### DIFF
--- a/src/main/java/spring/board/domain/AuditingFields.java
+++ b/src/main/java/spring/board/domain/AuditingFields.java
@@ -21,18 +21,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Column(nullable = false, updatable = false)
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @Column(nullable = false, updatable = false, length = 100)
     @CreatedBy
-    private String createdBy;
+    protected String createdBy;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Column(nullable = false)
     @LastModifiedDate
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 
     @Column(nullable = false, length = 100)
     @LastModifiedBy
-    private String modifiedBy;
+    protected String modifiedBy;
 }


### PR DESCRIPTION
이 PR은 `AudtingFields` 클래스 필드의 접근 제어자를 추상 클래스에 맞게 `protected`로 수정한다.

인증이 없는 상태에서 정보를 기록하기 위해 리팩토링한다.
대표적인 사례는 회원가입이다.

This closes #85 